### PR TITLE
feat: 메인페이지 뻔라인 조회 API 연동 및 카드 렌더링 구현

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,7 +11,6 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
-import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -23,11 +22,6 @@ const ProfileRoute = ProfileRouteImport.update({
 const OnboardingRoute = OnboardingRouteImport.update({
   id: '/onboarding',
   path: '/onboarding',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthRoute = AuthRouteImport.update({
@@ -44,14 +38,12 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
-  '/login': typeof LoginRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
-  '/login': typeof LoginRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
 }
@@ -59,22 +51,20 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
-  '/login': typeof LoginRoute
   '/onboarding': typeof OnboardingRoute
   '/profile': typeof ProfileRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/auth' | '/login' | '/onboarding' | '/profile'
+  fullPaths: '/' | '/auth' | '/onboarding' | '/profile'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/auth' | '/login' | '/onboarding' | '/profile'
-  id: '__root__' | '/' | '/auth' | '/login' | '/onboarding' | '/profile'
+  to: '/' | '/auth' | '/onboarding' | '/profile'
+  id: '__root__' | '/' | '/auth' | '/onboarding' | '/profile'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthRoute: typeof AuthRoute
-  LoginRoute: typeof LoginRoute
   OnboardingRoute: typeof OnboardingRoute
   ProfileRoute: typeof ProfileRoute
 }
@@ -93,13 +83,6 @@ declare module '@tanstack/react-router' {
       path: '/onboarding'
       fullPath: '/onboarding'
       preLoaderRoute: typeof OnboardingRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth': {
@@ -122,7 +105,6 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthRoute: AuthRoute,
-  LoginRoute: LoginRoute,
   OnboardingRoute: OnboardingRoute,
   ProfileRoute: ProfileRoute,
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,4 @@
-import {
-  createFileRoute,
-  redirect,
-  useRouter,
-} from "@tanstack/react-router";
+import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useState, useEffect } from "react";
 import BusinessCard from "../components/BusinessCard";
 import skating_icon_Default from "../assets/icons/skating_icon_Default.svg";
@@ -11,7 +7,7 @@ import snowflake_2 from "../assets/icons/snowflake_2.svg";
 import snowflake_4 from "../assets/icons/snowflake_4.svg";
 import Button from "../components/Button";
 import LocalStorageKeys from "../types/localstorage";
-import { registerBbunUser } from "../apis/user";
+import { registerBbunUser, getBbun } from "../apis/user";
 
 export const Route = createFileRoute("/")({
   /* 로그인 확인(임시) */
@@ -26,16 +22,42 @@ export const Route = createFileRoute("/")({
   component: MainPage,
 });
 
+interface BbunCardData {
+  uuid: string;
+  name: string;
+  studentNumber: string;
+  email: string;
+  profileImageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  consent: boolean;
+  department: string | null;
+  MBTI: string | null;
+  instaId: string | null;
+  description: string | null;
+}
+
 function MainPage() {
   const router = useRouter();
   const [isProfileRegistered, setIsProfileRegistered] = useState(false);
-  
+  const [bbunLineCards, setBbunLineCards] = useState<BbunCardData[]>([]);
+
   useEffect(() => {
     const hasProfile = localStorage.getItem(LocalStorageKeys.HasProfile);
     if (hasProfile === "true") {
       setIsProfileRegistered(true);
+      fetchBbunLine();
     }
   }, []);
+  const fetchBbunLine = async () => {
+    try {
+      const response = await getBbun();
+      setBbunLineCards(response.list || []);
+    } catch (error) {
+      console.error("Failed to fetch Bbun-line:", error);
+    }
+  };
 
   const handleLogoutClick = () => {
     localStorage.removeItem(LocalStorageKeys.AccessToken);
@@ -47,33 +69,6 @@ function MainPage() {
   };
 
   const dummyCards = [1, 2, 3];
-
-  const realCards = [
-    {
-      name: "지니",
-      studentId: "20230001",
-      email: "example@gist.ac.kr",
-      centerColor: "blue",
-      instagramId: "@aaa",
-      department: "전기전자컴퓨터공학과",
-    },
-    {
-      name: "어스",
-      studentId: "20240001",
-      email: "example@gist.ac.kr",
-      centerColor: "purple",
-      instagramId: "@bbb",
-      department: "전기전자컴퓨터공학과",
-    },
-    {
-      name: "예시",
-      studentId: "20250001",
-      email: "example@gist.ac.kr",
-      centerColor: "pink",
-      instagramId: "@ccc",
-      department: "도전탐색과정",
-    },
-  ];
 
   return (
     <div className="w-full h-[100dvh] overflow-y-auto scrollbar-hide overflow-x-hidden">
@@ -116,6 +111,8 @@ function MainPage() {
           )}
         </div>
 
+        {/* 뻔카드 목록 */}
+
         <div
           className={`z-10 w-full flex flex-col justify-start items-center gap-[16px] pt-[20px] pb-[20px] mb-[24px] ${
             !isProfileRegistered ? "blur-[5px]" : ""
@@ -125,24 +122,25 @@ function MainPage() {
             ? dummyCards.map((_, index) => (
                 <BusinessCard
                   key={index}
-                  name="지니"
-                  studentId="20260001"
+                  name="이름"
+                  studentId="20260000"
                   email="example@gm.gist.ac.kr"
                   centerColor="blue"
-                  instagramId="@aaa"
-                  department="도전탐색과정"
+                  instagramId="instaId"
+                  department="GS"
                 />
               ))
-            : realCards.map((card, index) => (
+            : bbunLineCards.map((card, index) => (
                 <BusinessCard
-                  key={index}
+                  key={card.uuid || index}
                   name={card.name}
-                  studentId={card.studentId}
+                  studentId={card.studentNumber}
                   email={card.email}
-                  centerColor={card.centerColor}
-                  instagramId={card.instagramId}
+                  centerColor={
+                    ["blue", "purple", "pink", "yellow", "green"][index % 5]
+                  } // 색상 나중에 랜덤으로
+                  instagramId={card.instaId || ""}
                   department={card.department}
-                  isPreview={card.isPreview}
                 />
               ))}
         </div>

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,5 +1,10 @@
 import { createFileRoute, useRouter } from "@tanstack/react-router";
-import { getBbunUser, getUser, updateBbunUser, withdrawBbunUser } from "../apis/user";
+import {
+  getBbunUser,
+  getUser,
+  updateBbunUser,
+  withdrawBbunUser,
+} from "../apis/user";
 import { useEffect, useState } from "react";
 import snowflake_1 from "../assets/icons/snowflake_1.svg";
 import snowflake_4 from "../assets/icons/snowflake_4.svg";
@@ -23,7 +28,9 @@ function ProfilePage() {
   const [mbti, setMbti] = useState("");
   const [instagramId, setInstagramId] = useState("");
   const [agreement, setAgreement] = useState(false);
-  const [hasProfile, setHasProfile] = useState(localStorage.getItem(LocalStorageKeys.HasProfile) === "true");
+  const [hasProfile, setHasProfile] = useState(
+    localStorage.getItem(LocalStorageKeys.HasProfile) === "true",
+  );
 
   const mbtiList = [
     "ENFJ",
@@ -58,29 +65,32 @@ function ProfilePage() {
   ];
 
   useEffect(() => {
-    if(localStorage.getItem(LocalStorageKeys.HasProfile) === "true") {
-      getBbunUser().then((data) => {
-        setName(data.name || "");
-        setStudentId(data.studentNumber || "");
-        setEmail(data.email || "");
-        setMajor(data.department || "");
-        setMbti(data.MBTI || "");
-        setInstagramId(data.instaId || "");
-      }).catch((error) => {
-        console.error("Failed to fetch profile:", error);
-        alert("프로필 정보를 불러오는데 실패했습니다.");
-      });
+    if (localStorage.getItem(LocalStorageKeys.HasProfile) === "true") {
+      getBbunUser()
+        .then((data) => {
+          setName(data.name || "");
+          setStudentId(data.studentNumber || "");
+          setEmail(data.email || "");
+          setMajor(data.department || "");
+          setMbti(data.MBTI || "");
+          setInstagramId(data.instaId || "");
+        })
+        .catch((error) => {
+          console.error("Failed to fetch profile:", error);
+          alert("프로필 정보를 불러오는데 실패했습니다.");
+        });
     } else {
-      getUser().then((data) => {
-        setName(data.user_name || "");
-        setStudentId(data.student_id || "");
-        setEmail(data.user_email_id || "");
-      }).catch((error) => {
-        console.error("Failed to fetch user:", error);
-        alert("사용자 정보를 불러오는데 실패했습니다.");
-      });
+      getUser()
+        .then((data) => {
+          setName(data.user_name || "");
+          setStudentId(data.student_id || "");
+          setEmail(data.user_email_id || "");
+        })
+        .catch((error) => {
+          console.error("Failed to fetch user:", error);
+          alert("사용자 정보를 불러오는데 실패했습니다.");
+        });
     }
-    
   }, []);
 
   const handleUpdateClick = async () => {
@@ -88,10 +98,10 @@ function ProfilePage() {
       alert("필수 항목(학번, 이름, 이메일)을 모두 입력해주세요.");
       return;
     }
-    
+
     try {
       // registerBbunUser는 index.tsx에서 수행됨
-      
+
       const profileData = {
         department: major,
         MBTI: mbti,
@@ -100,7 +110,7 @@ function ProfilePage() {
       };
 
       await updateBbunUser(profileData);
-      if(!hasProfile) {
+      if (!hasProfile) {
         localStorage.setItem(LocalStorageKeys.HasProfile, "true");
         setHasProfile(true);
       }
@@ -217,14 +227,14 @@ function ProfilePage() {
                   placeholder="인스타그램 아이디를 입력해주세요."
                 />
               </div>
-              
+
               {hasProfile ? (
                 <div className="flex flex-col gap-[10px]">
                   <div className="flex flex-col gap-[6px]">
                     <div className="text-[18px] font-bold">회원 탈퇴</div>
                     <div className="text-[12px]">
-                      개인 정보 동의를 철회하려면 회원 탈퇴가 필요합니다. 이 행위는
-                      되돌릴 수 없습니다.
+                      개인 정보 동의를 철회하려면 회원 탈퇴가 필요합니다. 이
+                      행위는 되돌릴 수 없습니다.
                     </div>
                   </div>
 
@@ -239,29 +249,27 @@ function ProfilePage() {
                   </button>
                 </div>
               ) : (
-              <div className="flex flex-col gap-[10px]">
-                <div className="flex flex-col gap-[6px]">
-                  <div className="text-[18px] font-bold">
-                    개인 정보 제공에 동의하십니까?
+                <div className="flex flex-col gap-[10px]">
+                  <div className="flex flex-col gap-[6px]">
+                    <div className="text-[18px] font-bold">
+                      개인 정보 제공에 동의하십니까?
+                    </div>
+                    <div className="text-[12px]">
+                      동의하지 않을 시 서비스 이용이 불가능합니다.
+                    </div>
                   </div>
-                  <div className="text-[12px]">
-                    동의하지 않을 시 서비스 이용이 불가능합니다.
-                  </div>
+
+                  <label className="flex items-center gap-[8px] cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={agreement}
+                      onChange={(e) => setAgreement(e.target.checked)}
+                      className="w-5 h-5 cursor-pointer"
+                    />
+                    <span className="text-[15px] font-bold">동의합니다.</span>
+                  </label>
                 </div>
-                
-                <label className="flex items-center gap-[8px] cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={agreement}
-                    onChange={(e) => setAgreement(e.target.checked)}
-                    className="w-5 h-5 cursor-pointer"
-                  />
-                  <span className="text-[15px] font-bold">동의합니다.</span>
-                </label>
-              </div>)}
-
-              
-
+              )}
             </div>
           </div>
         </div>
@@ -270,9 +278,12 @@ function ProfilePage() {
             label={hasProfile ? "수정" : "등록"}
             onClick={handleUpdateClick}
             disabled={
-              hasProfile ? 
-              !studentId.trim() || !name.trim() || !email.trim() :
-              !agreement || !studentId.trim() || !name.trim() || !email.trim()
+              hasProfile
+                ? !studentId.trim() || !name.trim() || !email.trim()
+                : !agreement ||
+                  !studentId.trim() ||
+                  !name.trim() ||
+                  !email.trim()
             }
           />
         </div>


### PR DESCRIPTION
1. 메인페이지 뻔라인 조회 API 연동
* 로그인 후 메인페이지에서 실제 사용자 정보가 카드에 표시됩니다.

2. 카드 색상 지정
* 카드 색상은 위에서부터 순서대로 blue, purple, pink, yellow, green이 반복되도록 했습니다.
* 추후 카드 색상 설정 로직이 생기면 수정이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 뻔카드 목록이 동적으로 로드되며, 사용자 프로필 등록 여부에 따라 실시간 데이터로 카드 목록을 표시합니다.

* **Chores**
  * 라우팅 정리: 공개 루트 트리에서 '/login' 경로 및 관련 공개 참조가 제거되어 라우트 목록이 단순화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->