### PR TITLE
feat: 토큰 만료 시 온보딩 페이지로 리다이렉트

### DIFF
--- a/src/apis/interceptor.ts
+++ b/src/apis/interceptor.ts
@@ -13,4 +13,21 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+api.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem(LocalStorageKeys.AccessToken);
+      localStorage.removeItem(LocalStorageKeys.IdToken);
+      localStorage.removeItem(LocalStorageKeys.BbunAccessToken);
+      localStorage.removeItem(LocalStorageKeys.HasProfile);
+
+      window.location.href = "/onboarding";
+    }
+    return Promise.reject(error);
+  },
+);
+
 export default api;

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,52 +1,41 @@
 import api from "./interceptor";
-import axios from "axios";
 import LocalStorageKeys from "../types/localstorage";
 
 interface ProfileData {
-    department?: string;
-    MBTI?: string;
-    instaId?: string;
-    description?: string;
+  department?: string;
+  MBTI?: string;
+  instaId?: string;
+  description?: string;
 }
-
 
 const IDP_API_URL = import.meta.env.VITE_IDP_API_URL;
 
 export const getUser = async () => {
-    const token = localStorage.getItem(LocalStorageKeys.AccessToken);
-    if (!token) {
-        throw new Error("Missing access_token");
-    }
-    return axios
-        .get(`${IDP_API_URL}/oauth2/userinfo`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .then(({ data }) => data);
+  const token = localStorage.getItem(LocalStorageKeys.AccessToken);
+  if (!token) {
+    throw new Error("Missing access_token");
+  }
+  return api
+    .get(`${IDP_API_URL}/oauth2/userinfo`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    .then(({ data }) => data);
 };
 
 export const registerBbunUser = async () => {
-    return api
-        .post(`/user`,{})
-        .then(({ data }) => data);
+  return api.post(`/user`, {}).then(({ data }) => data);
 };
 
 export const getBbunUser = async () => {
-    return api
-        .get(`/user`)
-        .then(({ data }) => data);
+  return api.get(`/user`).then(({ data }) => data);
 };
 
 export const updateBbunUser = async (profileData: ProfileData) => {
-    return api
-        .patch(`/user`, profileData)
-        .then(({ data }) => data);
+  return api.patch(`/user`, profileData).then(({ data }) => data);
 };
 
 export const withdrawBbunUser = async () => {
-    return api
-        .delete(`/user`)
-        .then(({ data }) => data);
+  return api.delete(`/user`).then(({ data }) => data);
 };
-

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,28 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Outlet, redirect } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/router-devtools";
+import LocalStorageKeys from "../types/localstorage";
 
 export const Route = createRootRoute({
+  beforeLoad: ({ location }) => {
+    const isAuthenticated = localStorage.getItem(LocalStorageKeys.AccessToken);
+
+    const publicPaths = ["/onboarding", "/auth"];
+    const isPublicPath = publicPaths.some((path) =>
+      location.pathname.startsWith(path),
+    );
+
+    if (!isAuthenticated && !isPublicPath) {
+      throw redirect({
+        to: "/onboarding",
+      });
+    }
+
+    if (isAuthenticated && isPublicPath) {
+      throw redirect({
+        to: "/",
+      });
+    }
+  },
   component: RootComponent,
 });
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { useState, useEffect } from "react";
 import BusinessCard from "../components/BusinessCard";
 import skating_icon_Default from "../assets/icons/skating_icon_Default.svg";
@@ -13,15 +13,6 @@ import { bbunLogout } from "../apis/auth";
 import { reverseDepartmentMap } from "../types/department";
 
 export const Route = createFileRoute("/")({
-  /* 로그인 확인(임시) */
-  beforeLoad: () => {
-    const isAuthenticated = localStorage.getItem(LocalStorageKeys.AccessToken);
-    if (!isAuthenticated) {
-      throw redirect({
-        to: "/onboarding",
-      });
-    }
-  },
   component: MainPage,
 });
 
@@ -170,9 +161,7 @@ function MainPage() {
                     card.department ||
                     ""
                   }
-                  onClick={() =>
-                    handleCardClick(card)
-                  }
+                  onClick={() => handleCardClick(card)}
                 />
               ))}
               {bbunLineCards.length <= 1 &&
@@ -206,10 +195,7 @@ function MainPage() {
               }}
             />
           ) : (
-            <Button
-              label="로그아웃"
-              onClick={handleLogoutClick}
-            />
+            <Button label="로그아웃" onClick={handleLogoutClick} />
           )}
           <button
             className="text-gray-400 text-xs mb-2"
@@ -218,7 +204,6 @@ function MainPage() {
             테스트용 로그아웃 (토큰/프로필 초기화)
           </button>
         </div>
-        
       </div>
     </div>
   );


### PR DESCRIPTION
1. 온보딩 페이지로 리다이렉트
* 로그인하지 않은 상태에서 온보딩 외의 페이지에 접근할 시 온보딩 페이지로 리다이렉트됩니다.
* 토큰이 만료되었을 때 또한 온보딩 페이지로 리다이렉트됩니다.

2. 메인 페이지로 리다이렉트
* 로그인한 상테에서 온보딩 페이지로 접근하면 메인페이지로 리다이렉트됩니다.

3. 주소창으로 auth 접근 막기
* 주소창에서 /auth를 쳐서 auth 페이지로 접근이 가능해서 이 경우도 온보딩 페이지로 리다이렉트되게 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증되지 않은 사용자를 자동으로 온보딩 페이지로 리디렉션하는 인증 게이트 추가
  * OAuth 플로우 검증으로 유효한 인증 상태만 허용
  * 무효한 세션 시 자동 로그아웃 및 페이지 리다이렉션 기능 구현

* **개선사항**
  * 중앙화된 API 요청 처리로 인증 관리 강화
  * 인증 상태에 따른 페이지 접근 제어 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->